### PR TITLE
chore(android): update mediapipe genai to 0.10.24

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,5 @@ repositories {
 
 dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1"
-  implementation "com.google.mediapipe:tasks-genai:0.10.22"
+  implementation "com.google.mediapipe:tasks-genai:0.10.24"
 }


### PR DESCRIPTION
## Summary
- bump the Mediapipe GenAI tasks dependency to version 0.10.24 in the Android library module

## Testing
- ⚠️ `cd example/android && ./gradlew clean assemble` *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d56bddc5cc832faa93a372ce08abbf