### PR TITLE
chore: bump MediaPipe tasks pods to 0.10.24

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -47,9 +47,9 @@ PODS:
   - hermes-engine (0.76.7):
     - hermes-engine/Pre-built (= 0.76.7)
   - hermes-engine/Pre-built (0.76.7)
-  - MediaPipeTasksGenAI (0.10.21):
-    - MediaPipeTasksGenAIC (= 0.10.21)
-  - MediaPipeTasksGenAIC (0.10.21)
+  - MediaPipeTasksGenAI (0.10.24):
+    - MediaPipeTasksGenAIC (= 0.10.24)
+  - MediaPipeTasksGenAIC (0.10.24)
   - RCT-Folly (2024.10.14.00):
     - boost
     - DoubleConversion
@@ -1965,8 +1965,8 @@ SPEC CHECKSUMS:
   fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
   glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
   hermes-engine: eb4a80f6bf578536c58a44198ec93a30f6e69218
-  MediaPipeTasksGenAI: 64f91ec1f2666abeb6dc719a8e8d1e2bf36374c0
-  MediaPipeTasksGenAIC: 1df8d7c6fcbe797d2a04a514edd8b31445291ec8
+  MediaPipeTasksGenAI: 076ba7032a6e9da16db9c7cf0c3b67c751c18bc1
+  MediaPipeTasksGenAIC: ec35d9f431f6a6b651a0bc9f67a4ed149ffa575c
   RCT-Folly: ea9d9256ba7f9322ef911169a9f696e5857b9e17
   RCTDeprecation: ebe712bb05077934b16c6bf25228bdec34b64f83
   RCTRequired: ca91e5dd26b64f577b528044c962baf171c6b716

--- a/ios/ExpoLlmMediapipe.podspec
+++ b/ios/ExpoLlmMediapipe.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.dependency 'ExpoModulesCore'
   
   # MediaPipe LLM dependencies - need both
-  s.dependency 'MediaPipeTasksGenAI' 
-  s.dependency 'MediaPipeTasksGenAIC'
+  s.dependency 'MediaPipeTasksGenAI', '>= 0.10.24'
+  s.dependency 'MediaPipeTasksGenAIC', '>= 0.10.24'
   
   s.source_files = "*.{swift}"
 end


### PR DESCRIPTION
## Summary
- raise the ExpoLlmMediapipe podspec constraints to require MediaPipeTasksGenAI/C 0.10.24 or newer
- update the example iOS Podfile.lock to resolve MediaPipeTasksGenAI/C at 0.10.24 with refreshed checksums

## Testing
- not run (iOS build tooling such as xcodebuild is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d56d6ced1c832f8b09746f4dfc21f5