### PR TITLE
Fix npm exec invocation on Windows

### DIFF
--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -32,8 +32,17 @@ function runCommand(command, args, options = {}) {
 }
 
 function runNpmExec(args, options = {}) {
-  const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-  return runCommand(npmCommand, ['exec', ...args], options);
+  if (process.platform === 'win32') {
+    const npmCliPath = process.env.npm_execpath;
+
+    if (!npmCliPath) {
+      throw new Error('The npm_execpath environment variable is not defined.');
+    }
+
+    return runCommand(process.execPath, [npmCliPath, 'exec', ...args], options);
+  }
+
+  return runCommand('npm', ['exec', ...args], options);
 }
 
 if (process.platform !== 'win32') {


### PR DESCRIPTION
## Summary
- update scripts/prepare.js so Windows invokes npm exec via Node and npm_execpath instead of npm.cmd
- retain the existing spawnSync behavior for non-Windows platforms

## Testing
- npm install

------
https://chatgpt.com/codex/tasks/task_e_68d57e2f0278832fae04981fb351410a