### PR TITLE
Ensure npm exec commands pass through argument delimiter

### DIFF
--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -39,10 +39,10 @@ function runNpmExec(args, options = {}) {
       throw new Error('The npm_execpath environment variable is not defined.');
     }
 
-    return runCommand(process.execPath, [npmCliPath, 'exec', ...args], options);
+    return runCommand(process.execPath, [npmCliPath, 'exec', '--', ...args], options);
   }
 
-  return runCommand('npm', ['exec', ...args], options);
+  return runCommand('npm', ['exec', '--', ...args], options);
 }
 
 if (process.platform !== 'win32') {


### PR DESCRIPTION
## Summary
- insert npm's `--` argument separator when invoking `npm exec`
- ensure both Windows and Unix code paths consistently forward command arguments

## Testing
- node scripts/prepare.js

------
https://chatgpt.com/codex/tasks/task_e_68d57ff3a194832f94c64e9e77125a6c