### PR TITLE
chore: bump tasks-genai to 0.10.29

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,5 @@ repositories {
 
 dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1"
-  implementation "com.google.mediapipe:tasks-genai:0.10.24"
+  implementation "com.google.mediapipe:tasks-genai:0.10.29"
 }


### PR DESCRIPTION
## Summary
- update the Android library dependency on com.google.mediapipe:tasks-genai to version 0.10.29

## Testing
- ./gradlew :expo-llm-mediapipe:assemble *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d9ea16bc832f99f7fa1b174144fc