### PR TITLE
chore: bump coroutines android to 1.10.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,6 +46,6 @@ repositories {
 }
 
 dependencies {
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.1"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
   implementation "com.google.mediapipe:tasks-genai:0.10.29"
 }


### PR DESCRIPTION
## Summary
- update the android module to use kotlinx-coroutines-android 1.10.2

## Testing
- ⚠️ ./gradlew :expo-llm-mediapipe:test (fails: Android SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d7da5d7c5c832f8bf10ab1a488ea1c