### PR TITLE
Handle download completions without progress events

### DIFF
--- a/src/ExpoLlmMediapipeModule.ts
+++ b/src/ExpoLlmMediapipeModule.ts
@@ -141,6 +141,20 @@ function useDownloadableLLM(
         setDownloadProgress(0);
         setDownloadError(null);
         const result = await module.downloadModel(modelUrl, modelName, options);
+        if (result) {
+          try {
+            const isDownloaded = await module.isModelDownloaded(modelName);
+            if (isDownloaded) {
+              setDownloadStatus("downloaded");
+              setDownloadProgress(1);
+            }
+          } catch (statusCheckError) {
+            console.warn(
+              `Unable to verify download status for ${modelName}:`,
+              statusCheckError,
+            );
+          }
+        }
         return result;
       } catch (error) {
         console.error(`Error initiating download for ${modelName}:`, error);

--- a/src/ModelManager.ts
+++ b/src/ModelManager.ts
@@ -132,6 +132,23 @@ export class ModelManager {
         modelName,
         downloadOptions,
       );
+      if (result) {
+        try {
+          const isDownloaded = await ExpoLlmMediapipe.isModelDownloaded(modelName);
+          if (isDownloaded) {
+            model.status = "downloaded";
+            model.progress = 1;
+            model.error = undefined;
+            this.models.set(modelName, model);
+            this.notifyListeners();
+          }
+        } catch (statusCheckError) {
+          console.warn(
+            `Unable to verify download status for ${modelName}:`,
+            statusCheckError,
+          );
+        }
+      }
       return result;
     } catch (error) {
       // Update status to error


### PR DESCRIPTION
## Summary
- update the downloadable hook to verify completion when native downloads resolve without emitting progress
- mirror the completion verification in the model manager to keep tracked metadata in sync

## Testing
- not run (native module requires platform-specific runtime)


------
https://chatgpt.com/codex/tasks/task_e_68d83d907170832fb2e9b1ef33f669c2