### PR TITLE
Handle download cancellation gracefully

### DIFF
--- a/src/ExpoLlmMediapipeModule.ts
+++ b/src/ExpoLlmMediapipeModule.ts
@@ -158,10 +158,22 @@ function useDownloadableLLM(
         return result;
       } catch (error) {
         console.error(`Error initiating download for ${modelName}:`, error);
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        const errorCode = (error as { code?: string | undefined })?.code;
+        const isCancelled =
+          errorCode === "ERR_DOWNLOAD_CANCELLED" ||
+          errorMessage.toLowerCase().includes("cancelled");
+
+        if (isCancelled) {
+          setDownloadStatus("not_downloaded");
+          setDownloadProgress(0);
+          setDownloadError(null);
+          return false;
+        }
+
         setDownloadStatus("error");
-        setDownloadError(
-          error instanceof Error ? error.message : String(error),
-        );
+        setDownloadError(errorMessage);
         throw error;
       }
     },

--- a/src/ModelManager.ts
+++ b/src/ModelManager.ts
@@ -151,6 +151,22 @@ export class ModelManager {
       }
       return result;
     } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      const errorCode = (error as { code?: string | undefined })?.code;
+      const isCancelled =
+        errorCode === "ERR_DOWNLOAD_CANCELLED" ||
+        errorMessage.toLowerCase().includes("cancelled");
+
+      if (isCancelled) {
+        model.status = "not_downloaded";
+        model.progress = 0;
+        model.error = undefined;
+        this.models.set(modelName, model);
+        this.notifyListeners();
+        return false;
+      }
+
       // Update status to error
       model.status = "error";
       // model.error = error.message;


### PR DESCRIPTION
## Summary
- detect cancellation errors when calling `downloadModel` and reset download state instead of surfacing an error
- mirror the same cancellation handling in `ModelManager` so cancelled downloads revert to the not downloaded state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d83ef1b1ec832f8e351b9ffc2fc814