### PR TITLE
Add random seed support to Android LLM sessions

### DIFF
--- a/android/src/main/java/expo/modules/llmmediapipe/LlmInferenceModel.kt
+++ b/android/src/main/java/expo/modules/llmmediapipe/LlmInferenceModel.kt
@@ -42,11 +42,12 @@ class LlmInferenceModel(
         val sessionOptions = LlmInferenceSession.LlmInferenceSessionOptions.builder()
             .setTemperature(temperature)
             .setTopK(topK)
+            .setRandomSeed(randomSeed)
             .build()
 
         try {
             llmInferenceSession = LlmInferenceSession.createFromOptions(llmInference, sessionOptions)
-            inferenceListener?.logging(this, "LLM inference session created successfully")
+            inferenceListener?.logging(this, "LLM inference session created successfully with random seed: $randomSeed")
         } catch (e: Exception) {
             inferenceListener?.logging(this, "Error creating LLM inference session: ${e.message}")
             llmInference.close()
@@ -69,8 +70,9 @@ class LlmInferenceModel(
             val sessionOptions = LlmInferenceSession.LlmInferenceSessionOptions.builder()
                 .setTemperature(temperature)
                 .setTopK(topK)
+                .setRandomSeed(randomSeed)
                 .build()
-                
+
             llmInferenceSession = LlmInferenceSession.createFromOptions(llmInference, sessionOptions)
             
             // Add the prompt to the session
@@ -112,6 +114,7 @@ class LlmInferenceModel(
             val sessionOptions = LlmInferenceSession.LlmInferenceSessionOptions.builder()
                 .setTemperature(temperature)
                 .setTopK(topK)
+                .setRandomSeed(randomSeed)
                 .build()
                 
             llmInferenceSession = LlmInferenceSession.createFromOptions(llmInference, sessionOptions)


### PR DESCRIPTION
## Summary
- set the configured random seed on the initial LLM inference session and subsequent rebuilds
- log the random seed used during session creation for easier diagnostics
- verified that `LlmInferenceSessionOptions.Builder` in Mediapipe Tasks GenAI exposes `setRandomSeed`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8a9104e1c832fa8bf837ce6912d17