### PR TITLE
Validate downloaded model size on iOS

### DIFF
--- a/docs/docs/hookless-apis.md
+++ b/docs/docs/hookless-apis.md
@@ -206,7 +206,7 @@ await ExpoLlmMediapipe.cancelDownload('gemma-1.1-2b-it-int4.bin');
 
 ### **`isModelDownloaded`**
 
-Checks if a model is already downloaded.
+Checks if a model is already downloaded and that the downloaded file is non-empty.
 
 ##### **Parameters**
 

--- a/ios/ExpoLlmMediapipeModule.swift
+++ b/ios/ExpoLlmMediapipeModule.swift
@@ -129,8 +129,22 @@ public class ExpoLlmMediapipeModule: Module {
 
   private func isModelDownloaded(modelName: String, promise: Promise) {
     let modelURL = getModelURL(modelName: modelName)
-    let exists = FileManager.default.fileExists(atPath: modelURL.path)
-    promise.resolve(exists)
+    let fileManager = FileManager.default
+    guard fileManager.fileExists(atPath: modelURL.path) else {
+      promise.resolve(false)
+      return
+    }
+
+    do {
+      let attributes = try fileManager.attributesOfItem(atPath: modelURL.path)
+      if let fileSize = attributes[.size] as? NSNumber, fileSize.intValue > 0 {
+        promise.resolve(true)
+      } else {
+        promise.resolve(false)
+      }
+    } catch {
+      promise.resolve(false)
+    }
   }
 
   private func getDownloadedModels(promise: Promise) {


### PR DESCRIPTION
## Summary
- ensure `isModelDownloaded` checks that the stored model file both exists and has a non-zero size before reporting success
- document that the hookless API only reports downloads when a non-empty file is present

## Testing
- Manual: Swift script simulating an interrupted download to verify the new zero-byte guard

------
https://chatgpt.com/codex/tasks/task_e_68d8af2762b8832f9eb6617d2f1839fb