### PR TITLE
Add coroutine timeout handling for Android downloads

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -48,4 +48,6 @@ repositories {
 dependencies {
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2"
   implementation "com.google.mediapipe:tasks-genai:0.10.29"
+  testImplementation "junit:junit:4.13.2"
+  testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.10.2"
 }

--- a/android/src/test/java/expo/modules/llmmediapipe/DownloadWithTimeoutTest.kt
+++ b/android/src/test/java/expo/modules/llmmediapipe/DownloadWithTimeoutTest.kt
@@ -1,0 +1,68 @@
+package expo.modules.llmmediapipe
+
+import java.io.File
+import java.net.ServerSocket
+import kotlin.concurrent.thread
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class DownloadWithTimeoutTest {
+  private lateinit var serverSocket: ServerSocket
+  private lateinit var tempFile: File
+  private var serverThread = Thread()
+
+  @Before
+  fun setUp() {
+    serverSocket = ServerSocket(0)
+    tempFile = File.createTempFile("download", ".tmp")
+  }
+
+  @After
+  fun tearDown() {
+    if (::serverSocket.isInitialized && !serverSocket.isClosed) {
+      serverSocket.close()
+    }
+    if (::tempFile.isInitialized && tempFile.exists()) {
+      tempFile.delete()
+    }
+    if (serverThread.isAlive) {
+      serverThread.interrupt()
+      serverThread.join(1000)
+    }
+  }
+
+  @Test
+  fun downloadTimesOutWhenServerStalls() = runTest {
+    serverThread = thread {
+      serverSocket.use { server ->
+        val socket = server.accept()
+        try {
+          // Keep the connection open without sending any response to simulate a stall.
+          Thread.sleep(5000)
+        } catch (_: InterruptedException) {
+          // Allow the thread to exit when interrupted during teardown.
+        } finally {
+          socket.close()
+        }
+      }
+    }
+
+    val timeoutMillis = 1_000L
+    val url = "http://127.0.0.1:${serverSocket.localPort}/"
+
+    assertFailsWith<TimeoutCancellationException> {
+      downloadWithTimeout(
+        url = url,
+        timeoutMillis = timeoutMillis,
+        headers = null,
+        tempFile = tempFile,
+        isActive = { true },
+        onProgress = { _, _, _ -> }
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable helper that applies both connection and read timeouts while streaming downloads
- update the Android download pipeline to surface timeout and cancellation events and to reject the promise when a stall occurs
- add a JVM unit test and Gradle test dependencies to cover the stalled-download timeout scenario

## Testing
- gradle -p android test *(fails: Android Gradle plugin not configured in this standalone module)*

------
https://chatgpt.com/codex/tasks/task_e_68d8b0c2bd9c832fbb29bb155c4794cb