### PR TITLE
Handle download timeout events

### DIFF
--- a/example/src/screens/HooklessDownloadableDemoScreen.tsx
+++ b/example/src/screens/HooklessDownloadableDemoScreen.tsx
@@ -83,6 +83,15 @@ const HooklessDownloadableDemoScreen = () => {
             setDownloadStatus("error");
             setDownloadError(event.error || "Unknown download error");
             setError(`Download Error: ${event.error}`);
+            setDownloadProgress(0);
+            setIsLoadingAction(false); // Stop loading indicator
+          } else if (event.status === "timeout") {
+            const message = event.error || "Download timed out";
+            setDownloadStatus("error");
+            setDownloadError(message);
+            setError(`Download Timeout: ${message}`);
+            setDownloadProgress(0);
+            Alert.alert("Download Timeout", message);
             setIsLoadingAction(false); // Stop loading indicator
           } else if (event.status === "cancelled") {
             setDownloadStatus("not_downloaded");

--- a/example/src/screens/HooklessUtilityDemoScreen.tsx
+++ b/example/src/screens/HooklessUtilityDemoScreen.tsx
@@ -46,6 +46,11 @@ const HooklessUtilityDemoScreen = () => {
               fetchDownloadedModels(); // Refresh list
             } else if (event.status === "error") {
               setLastMessage(`Error downloading ${UTILITY_MODEL_NAME}: ${event.error}`);
+              setDownloadProgress(0);
+            } else if (event.status === "timeout") {
+              const message = event.error || "Download timed out.";
+              setLastMessage(`Timeout downloading ${UTILITY_MODEL_NAME}: ${message}`);
+              setDownloadProgress(0);
             } else if (event.status === "cancelled") {
               setLastMessage(`Download of ${UTILITY_MODEL_NAME} cancelled.`);
               setDownloadProgress(0);

--- a/src/ExpoLlmMediapipe.types.ts
+++ b/src/ExpoLlmMediapipe.types.ts
@@ -49,7 +49,7 @@ export interface DownloadProgressEvent {
   bytesDownloaded?: number;
   totalBytes?: number;
   progress?: number;
-  status: "downloading" | "completed" | "error" | "cancelled";
+  status: "downloading" | "completed" | "error" | "cancelled" | "timeout";
   error?: string;
 }
 

--- a/src/ExpoLlmMediapipeModule.ts
+++ b/src/ExpoLlmMediapipeModule.ts
@@ -103,6 +103,11 @@ function useDownloadableLLM(
         } else if (event.status === "error") {
           setDownloadStatus("error");
           setDownloadError(event.error || "Unknown error occurred");
+          setDownloadProgress(0);
+        } else if (event.status === "timeout") {
+          setDownloadStatus("error");
+          setDownloadError(event.error || "Download timed out");
+          setDownloadProgress(0);
         } else if (event.status === "cancelled") {
           setDownloadStatus("not_downloaded");
           setDownloadProgress(0);

--- a/src/ModelManager.ts
+++ b/src/ModelManager.ts
@@ -43,7 +43,7 @@ export class ModelManager {
       model.status =
         status === "completed"
           ? "downloaded"
-          : status === "error"
+          : status === "error" || status === "timeout"
             ? "error"
             : status === "downloading"
               ? "downloading"
@@ -53,14 +53,18 @@ export class ModelManager {
         model.progress = progress;
       }
 
-      if (status === "error") {
+      if (status === "error" || status === "timeout") {
         model.error = error ?? model.error;
+        model.progress = 0;
       } else if (
         status === "downloading" ||
         status === "completed" ||
         status === "cancelled"
       ) {
         model.error = undefined;
+        if (status === "cancelled") {
+          model.progress = 0;
+        }
       }
 
       // Save updated model info
@@ -140,7 +144,8 @@ export class ModelManager {
       );
       if (result) {
         try {
-          const isDownloaded = await ExpoLlmMediapipe.isModelDownloaded(modelName);
+          const isDownloaded =
+            await ExpoLlmMediapipe.isModelDownloaded(modelName);
           if (isDownloaded) {
             model.status = "downloaded";
             model.progress = 1;


### PR DESCRIPTION
## Summary
- allow download progress events to report a timeout status across the JS types
- treat timeout events as errors in the model manager and downloadable hook state
- update example screens to reset progress and surface timeout messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d8b813ef00832fb3115271b2244f77