### PR TITLE
Set model error message on download failure

### DIFF
--- a/src/ModelManager.ts
+++ b/src/ModelManager.ts
@@ -180,7 +180,7 @@ export class ModelManager {
 
       // Update status to error
       model.status = "error";
-      // model.error = error.message;
+      model.error = errorMessage;
       this.models.set(modelName, model);
       this.notifyListeners();
       throw error;


### PR DESCRIPTION
## Summary
- set the model error message when a download fails for reasons other than cancellation so listeners receive the failure reason

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8c20f8a64832f8fd3ee34fc8647e6